### PR TITLE
Fix search result limiting for connector runs

### DIFF
--- a/kenna/api.py
+++ b/kenna/api.py
@@ -301,7 +301,7 @@ class Kenna:
 
                 i += 1
                 if limit and i >= limit:
-                    break
+                    return
 
     def get_connector_run(
             self,


### PR DESCRIPTION
The following pull request addresses a defect in the how search results are restricted when looking up connector runs - the fix is to use a `return` statement in place of a `break` statement within a nested `for` loop - otherwise we remain in the scope of the outer loop.